### PR TITLE
Add navbar navigation

### DIFF
--- a/mixxer/src/components/Navbar.js
+++ b/mixxer/src/components/Navbar.js
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+export default function Navbar() {
+  return (
+    <nav style={{
+      display: "flex",
+      justifyContent: "space-between",
+      padding: "16px",
+      borderBottom: "1px solid #ccc"
+    }}>
+      <Link href="/">Mixxer</Link>
+
+      <div style={{display: "flex", gap: "15px"}}>
+        <Link href="/dashboard">Dashboard</Link>
+        <Link href="/feed">Feed</Link>
+        <Link href="/profile">Profile</Link>
+        <Link href="/login">Login</Link>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
Added a basic Navbar component for frontend navigation.

This sets up navigation structure for the frontend but does not implement functionality yet.

Pages like Dashboard, Feed, Profile, and Login can be built on top of this structure.